### PR TITLE
Fixed predict api name in Routes.Mal.json

### DIFF
--- a/Configuration/Routes.Mal.json
+++ b/Configuration/Routes.Mal.json
@@ -42,7 +42,7 @@
       "mal.predict": {
         "ClusterId": "malService",
         "Match": {
-          "Path": "/api/predict",
+          "Path": "/api/sensor/predict",
           "Methods": [ "POST" ]
         },
         "AuthorizationPolicy": "RequireAuth",


### PR DESCRIPTION
Just a quick fix to properly reference the API for predict